### PR TITLE
Fix minor README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,13 +165,13 @@ Precision-Recall (PR) measures the accuracy of bounding box overlap between pred
 | :-: | :-: | :-: |
 | <p align="center"> <img src="results/P_curve.png"/></p> | <p align="center"> <img src="results/R_curve.png"/></p> | <p align="center"> <img src="results/PR_curve.png"/></p> |
 
-The following metrics were measured on the valid dataset containing 171 images. High precision and recall scores were obtained on `with mask` and `without mask` classes. However, the performance on `mask weared incorrectly` class was poor due to the imbalanced data.
+The following metrics were measured on the valid dataset containing 171 images. High precision and recall scores were obtained on `with mask` and `without mask` classes. However, the performance on `mask worn incorrectly` class was poor due to the imbalanced data.
 
 | Class | #Labels | Precision | Recall | mAP<sup>val<br>0.5 | mAP<sup>val<br>0.5:0.95 |
 | :-: | :-: | :-: | :-: | :-: | :-: |
 | `with mask` | 630 | 0.94 | 0.9 | 0.95 | 0.64 |
 | `without mask` | 104 | 0.86 | 0.82 |  0.9 |  0.6 |
-| `mask weared incorrectly` | 20 | 0.72 | 0.3 | 0.43 | 0.24 |
+| `mask worn incorrectly` | 20 | 0.72 | 0.3 | 0.43 | 0.24 |
 | `total` | 754 | 0.84 | 0.67 | 0.76 | 0.49 |
 
 Note: You can improve the performance of the "mask worn incorrectly" class by using the data balancing script.


### PR DESCRIPTION
## Summary
- correct phrase "mask weared incorrectly" to "mask worn incorrectly"

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_684687edec50832db722bb887304376d